### PR TITLE
Fixed a couple of IPv6 related bugs. Updated CHANGELOG etc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.6.5 - 2015-08-11
+==================
+
+- Fixed a bug with IPv6 and large netmasks like /64. The cidrize function
+  now returns immediately with the correct result rather than looping
+  eternally. Added test case.
+- Also fixed the failing ipv6 test case
+
 0.6.4 - 2013-02-12
 ==================
 

--- a/cidrize.py
+++ b/cidrize.py
@@ -3,7 +3,7 @@
 
 __author__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 
 """
 Intelligently parse IPv4/IPv6 addresses, CIDRs, ranges, and wildcard matches to
@@ -316,12 +316,14 @@ def cidrize(ipstr, strict=False, modular=True):
             if isinstance(result, IPRange) and result.size >= MAX_RANGE_LEN:
                 log.debug('IPRange objects larger than /18 will always be strict.')
                 return result.cidrs()
+            if isinstance(result, IPNetwork):
+                return [result.cidr]
             return [spanning_cidr(result)]
         else:
             try:
                 return result.cidrs() # IPGlob and IPRange have .cidrs()
             except AttributeError as err:
-                return result.cidr    # IPNetwork has .cidr
+                return [result.cidr]    # IPNetwork has .cidr
 
     except (AddrFormatError, TypeError, ValueError) as err:
         if modular:

--- a/cidrize.py
+++ b/cidrize.py
@@ -41,6 +41,7 @@ log = logging
 # Pre-compiled re patterns. You know, for speed!
 cidr_re = re.compile(r"\d+\.\d+\.\d+\.\d+(?:\/\d+)?$")
 range_re = re.compile(r"\d+\.\d+\.\d+\.\d+\-\d+\.\d+\.\d+\.\d+$")
+range6_re = re.compile(r"[0-9a-fA-F]+:[0-9A-Fa-f:.]+\-[0-9a-fA-F]+:[0-9A-Fa-f:.]+$")
 glob_re = re.compile(r"\d+\.\d+\.\d+\.\*$")
 bracket_re = re.compile(r"(.*?)\.(\d+)[\[\{\(](.*)[\)\}\]]$") # parses '1.2.3.4[5-9]' or '1.2.3.[57]'
 hyphen_re = re.compile(r"(.*?)\.(\d+)\-(\d+)$")
@@ -277,6 +278,11 @@ def cidrize(ipstr, strict=False, modular=True):
         # Parse 1.2.3.118-1.2.3.121 range style
         elif range_re.match(ipstr):
             log.debug("Trying range style...")
+            result = parse_range(ipstr)
+
+        # Parse 2001::14-2002::1.2.3.121 range style
+        elif range6_re.match(ipstr):
+            log.debug("Trying range6 style...")
             result = parse_range(ipstr)
 
         # Parse 1.2.3.4-70 hyphen style

--- a/tests/test_cidrize.py
+++ b/tests/test_cidrize.py
@@ -41,6 +41,11 @@ class TestCidrize(unittest.TestCase):
         _input = '1.2.3.4-1.2.3.10'
         self.assertEqual(expected, cidrize.parse_range(_input))
 
+    def test_parse_range6(self):
+        expected = IPRange('2001::1.2.3.4', '2002:1234:abcd::ffee')
+        _input = '2001::1.2.3.4-2002:1234:abcd::ffee'
+        self.assertEqual(expected, cidrize.parse_range(_input))
+
     def test_range_style_strict(self):
         expected = [IPNetwork('1.2.3.118/31'), IPNetwork('1.2.3.120/31')]
         _input = '1.2.3.118-1.2.3.121'
@@ -122,6 +127,13 @@ class TestOutputStr(unittest.TestCase):
         sep = ', '
         expected = '10.20.30.40/29, 10.20.30.48/31, 10.20.30.50/32'
         self.assertEqual(expected, cidrize.output_str(cidr, sep))
+
+    def test_range6(self):
+        cidr = cidrize.cidrize('2001:1234::0.0.64.0-2001:1234::FFff')
+        sep = ', '
+        expected = '2001:1234::4000/114, 2001:1234::8000/113'
+        self.assertEqual(expected, cidrize.output_str(cidr, sep))
+
 
 class TestOptimizeNetworkRange(unittest.TestCase):
     def setUp(self):

--- a/tests/test_cidrize.py
+++ b/tests/test_cidrize.py
@@ -33,7 +33,7 @@ class TestCidrize(unittest.TestCase):
 
     def test_cidr_style_ipv6(self):
         expected = [IPNetwork('fe80:4::c62c:3ff:fe00:861e/128')]
-        _input = 'fe80::c62c:3ff:fe00:861e%en0'
+        _input = 'fe80:4::c62c:3ff:fe00:861e'
         self.assertEqual(expected, self.test(_input))
 
     def test_parse_range(self):
@@ -95,6 +95,11 @@ class TestCidrize(unittest.TestCase):
     def test_last_resort_ipv6(self):
         expected = [IPNetwork('2001:4b0:1668:2602::2/128')]
         _input = '2001:4b0:1668:2602::2/128'
+        self.assertEqual(expected, self.test(_input))
+
+    def test_large_ipv6(self):
+        expected = [IPNetwork('2001:4b0:1668:2602::2/64')]
+        _input = '2001:4b0:1668:2602::/64'
         self.assertEqual(expected, self.test(_input))
 
     def test_failure(self):


### PR DESCRIPTION
Hi

I fixed a bug in cidrize where it would take approximately forever to do:

cidrize('2001::8/64')

The code fell into the slow path and tried (I think) to enumerate all the intervening addresses.

It now works quickly. I also fixed another bug where it would sometime return the cidr object rather than a list of cidr objects.

I also made IPv6 ranges work.

Thanks

Philip