### PR TITLE
Python3 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.7.0 - 
+- Python3 support via six
+- Python2.6 required
+
 0.6.5 - 2015-08-11
 ==================
 

--- a/cidrize.py
+++ b/cidrize.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 __author__ = 'Jathan McCollum'
 __email__ = 'jathan@gmail.com'
-__version__ = '0.6.5'
+__version__ = '0.7.0'
 
 """
 Intelligently parse IPv4/IPv6 addresses, CIDRs, ranges, and wildcard matches to
@@ -14,14 +15,17 @@ The cidrize() function is the public interface. The module may also be run
 interactively for debugging purposes.
 """
 
+# stdlib
 import itertools
 import logging
-from netaddr import (AddrFormatError, IPAddress, IPGlob, IPNetwork, IPRange,
-                     IPSet, spanning_cidr)
 import os
 import re
 import socket
 import sys
+
+# pypi
+from netaddr import (AddrFormatError, IPAddress, IPGlob, IPNetwork, IPRange,
+                     IPSet, spanning_cidr)
 
 # Globals
 EVERYTHING = ['internet at large', '*', 'all', 'any', 'internet', '0.0.0.0',
@@ -377,15 +381,15 @@ def optimize_network_range(ipstr, threshold=0.9, verbose=DEBUG):
     ratio = float(len(strict)) / float(len(loose))
 
     if verbose:
-        print 'Subnet usage ratio: %s; Threshold: %s' % (ratio, threshold)
+        print('Subnet usage ratio: %s; Threshold: %s' % (ratio, threshold))
 
     if ratio >= threshold:
         if verbose:
-            print 'Over threshold, IP Parse Mode: LOOSE'
+            print('Over threshold, IP Parse Mode: LOOSE')
         result = loose.iter_cidrs()
     else:
         if verbose:
-            print 'Under threshold, IP Parse Mode: STRICT'
+            print('Under threshold, IP Parse Mode: STRICT')
         result = strict.iter_cidrs()
 
     return result
@@ -464,7 +468,7 @@ def dump(cidr):
     log.debug('dump(): Got? %r' % cidr)
 
     ip_first = IPAddress(cidr.first)
-    ip_firsthost = ip_first if single else cidr.iter_hosts().next()
+    ip_firsthost = ip_first if single else next(cidr.iter_hosts())
     ip_gateway = IPAddress(cidr.last - 1)
     ip_bcast = cidr.broadcast
     ip_netmask = cidr.netmask
@@ -529,7 +533,7 @@ debug output set the DEBUG environment variable.''')
     def phelp():
         """I help."""
         parser.print_help()
-        print notes
+        print(notes)
 
     if opts.help or len(args) == 1:
         phelp()
@@ -558,9 +562,9 @@ def main():
         cidr = cidrize(ipstr, modular=False)
         if cidr:
             if opts.verbose:
-                print dump(cidr),
+                print(dump(cidr),)
             else:
-                print output_str(cidr)
+                print(output_str(cidr))
     except IndexError:
         return -1
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 try:
     from setuptools import setup, Command
@@ -10,10 +11,10 @@ import sys
 import unittest
 
 #from cidrize import __version__
-__version__ = '0.6.4'
+__version__ = '0.7.0'
 
-if sys.version_info[:2] < (2, 4):
-    print "This package requires Python 2.4+. Sorry!"
+if sys.version_info[:2] < (2, 6):
+    print("This package requires Python 2.6+. Sorry!")
     sys.exit(-1)
 
 class CleanCommand(Command):
@@ -25,7 +26,7 @@ class CleanCommand(Command):
         self.files = './build ./dist ./MANIFEST ./*.pyc ./*.egg-info'
     def run(self):
         #files = './build ./dist ./MANIFEST ./*.pyc'
-        print 'Cleaning: %s' % self.files
+        print('Cleaning: %s' % self.files)
         os.system('rm -rf ' + self.files)
 
 class TestCommand(Command):
@@ -54,7 +55,8 @@ setup(
     author_email = 'jathan@gmail.com',
     py_modules = ['cidrize'],
     scripts = ['scripts/cidr'],
-    install_requires=['netaddr>=0.7.6'],
+    install_requires=['netaddr>=0.7.6',],
+    tests_require=['netaddr>=0.7.6', ],
     keywords = [
             'Networking', 'Systems Administration', 'IANA', 'IEEE', 'CIDR', 'IP',
             'IPv4', 'IPv6', 'IP Address', 'Firewalls', 'Security',
@@ -73,9 +75,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Education :: Testing',
         'Topic :: Internet',
         'Topic :: Internet :: Name Service (DNS)',


### PR DESCRIPTION
Any chance of approving this and releasing something to PyPi? I'd really love to not run a custom version of cirdize.

The changes are:

* `print` statement upgraded to `print()` function
* `foo.next()` replaced with `next(foo)`.  this requires Python2.6, so I pushed the minimum version to that.  Python2.5 could be supported with the `six` module and `six.next(foo)`, but there's no real reason to support 2.5 or 2.6 anymore.
* i reorganized the imports to list what is from stdlib and what is from pypi

tests pass on py27 and py36

