### PR TITLE
ci: upgrade setup-uv to v7, fix release-preview, and upgrade PSR to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+      - name: Install uv & Python
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
+          version: "0.10.0"
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-python: true
+          cache-suffix: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -44,18 +43,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          version: "0.10.0"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
+      - name: Install ruff
         run: |
-          uv pip install --system ruff
+          uv tool install ruff
 
       - name: Run ruff check
         run: |
@@ -72,15 +66,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+      - name: Install uv & Python
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
+          version: "0.10.0"
           python-version: "3.11"
+          enable-cache: true
+          cache-python: true
 
       - name: Build package
         run: |

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -23,55 +23,86 @@ jobs:
           git checkout -B main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          version: "0.10.0"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: |
-          uv pip install --system python-semantic-release
-
-      - name: Get next version
+      - name: Compute version and changelog
         id: version
         run: |
-          NEXT_VERSION=$(python-semantic-release version --print || echo "No version change")
-          echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
-          python-semantic-release changelog --unreleased > /tmp/changelog.md || echo "No changes" > /tmp/changelog.md
+          uv tool install 'python-semantic-release>=10,<11'
 
-      - name: Comment PR
+          # Get next version (--print-only is the dry-run flag in PSR v10)
+          NEXT_VERSION=$(python-semantic-release version --print-only || echo "No version change")
+          echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
+
+          # Generate changelog: delete the existing file so PSR regenerates
+          # from scratch (produces a proper "## Unreleased" section).
+          rm -f CHANGELOG.md
+          python-semantic-release changelog
+
+          # Extract the Unreleased section (strip the heading itself)
+          CHANGELOG=$(sed -n '/^## Unreleased/,/^## v/{/^## Unreleased/d;/^## v/d;p}' CHANGELOG.md)
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="No changes detected."
+          fi
+
+          # Write to file for the next step (multi-line safe)
+          echo "$CHANGELOG" > /tmp/changelog-preview.md
+
+      - name: Upsert PR comment
         uses: actions/github-script@v7
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         with:
           script: |
             const fs = require('fs');
-            const nextVersion = '${{ steps.version.outputs.next_version }}';
-            const changelog = fs.readFileSync('/tmp/changelog.md', 'utf8');
+            const marker = '<!-- release-preview-bot -->';
+            const nextVersion = process.env.NEXT_VERSION;
+            const changelog = fs.readFileSync('/tmp/changelog-preview.md', 'utf8').trim();
 
-            const body = `## 🚀 Release Preview
+            const body = [
+              marker,
+              '## Release Preview',
+              '',
+              `**Next Version:** \`${nextVersion}\``,
+              '',
+              '### Changelog Preview',
+              '',
+              changelog,
+              '',
+              '---',
+              '',
+              '*This version will be automatically released when this PR is merged to main.*',
+              '',
+              '**Reminder:** Use conventional commits:',
+              '- `fix:` → Patch release (2.1.1 → 2.1.2)',
+              '- `feat:` → Minor release (2.1.1 → 2.2.0)',
+              '- `feat!:` or `BREAKING CHANGE:` → Major release (2.1.1 → 3.0.0)',
+            ].join('\n');
 
-            **Next Version:** \`${nextVersion}\`
-
-            ### Changelog Preview
-
-            ${changelog}
-
-            ---
-
-            *This version will be automatically released when this PR is merged to main.*
-
-            **Reminder:** Use conventional commits:
-            - \`fix:\` → Patch release (2.1.1 → 2.1.2)
-            - \`feat:\` → Minor release (2.1.1 → 2.2.0)
-            - \`feat!:\` or \`BREAKING CHANGE:\` → Major release (2.1.1 → 3.0.0)
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            // Look for an existing comment with our marker (paginate to search all)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              issue_number: context.issue.number,
             });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+              console.log(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+              console.log('Created new comment');
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,14 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+          version: "0.10.0"
+          enable-cache: false
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9
+        uses: python-semantic-release/python-semantic-release@v10
         with:
           github_token: ${{ secrets.RELEASE_TOKEN }}
 
@@ -55,15 +51,13 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.tag || github.ref }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+      - name: Install uv & Python
+        uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
+          version: "0.10.0"
           python-version: "3.11"
+          enable-cache: true
+          cache-python: true
 
       - name: Build package
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,8 @@ minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.changelog]
+
+[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
## Summary
- Upgrade `astral-sh/setup-uv` from `@v3` to `@v7` across all 3 workflow files, pin uv `0.10.0`
- Remove redundant `actions/setup-python@v5` steps — `setup-uv@v7` handles Python installation natively
- Switch `uv pip install --system` to `uv tool install` for ruff and python-semantic-release
- Fix release-preview changelog: replace broken `--unreleased` flag with delete-and-regenerate approach (PSR v10 compat)
- Upsert PR comments using `<!-- release-preview-bot -->` HTML marker instead of creating duplicates on every push
- Upgrade `python-semantic-release/python-semantic-release` action from `@v9` to `@v10`
- Move `changelog_file` to `[tool.semantic_release.changelog.default_templates]` per PSR v10

Ported from jathanism/nsot#67.

## Test plan
- [ ] CI workflow: test/lint/build jobs pass with `setup-uv@v7`
- [ ] Release preview: changelog generates correctly with delete-and-regenerate approach
- [ ] Release preview: PR comment is upserted (not duplicated) on subsequent pushes
- [ ] No cache API 400/503 errors on second CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI/release automation (tooling versions, caching, changelog generation, and PR commenting), which can break pipelines even though no runtime code is affected.
> 
> **Overview**
> Upgrades GitHub Actions workflows to `astral-sh/setup-uv@v7` (pinning `uv` to `0.10.0`) and removes separate `actions/setup-python` steps by letting `setup-uv` install Python; caching is adjusted to include per-Python caches.
> 
> Updates lint/release tooling to use `uv tool install` (e.g., `ruff` and `python-semantic-release`) and bumps `python-semantic-release` from `v9` to `v10`, including PSR v10 CLI flag/config changes.
> 
> Fixes the release-preview workflow by regenerating `CHANGELOG.md` to extract the `Unreleased` section and by *upserting* a single PR comment via a marker instead of creating duplicate comments on every push.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7372d1ae7b63864228df505b5d541887b2069034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->