### PR TITLE
feat: upgrade netaddr from 0.8 to 1.x

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           uv tool install 'python-semantic-release>=10,<11'
 
-          # Get next version (--print-only is the dry-run flag in PSR v10)
-          NEXT_VERSION=$(python-semantic-release version --print-only || echo "No version change")
+          # Get next version (--print is the dry-run flag in PSR v10)
+          NEXT_VERSION=$(python-semantic-release version --print || echo "No version change")
           echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
 
           # Generate changelog: delete the existing file so PSR regenerates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "netaddr~=0.8.0",
+    "netaddr>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -111,7 +111,7 @@ wheels = [
 
 [[package]]
 name = "cidrize"
-version = "2.1.1"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "netaddr" },
@@ -126,7 +126,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "netaddr", specifier = "~=0.8.0" },
+    { name = "netaddr", specifier = ">=1.0.0,<2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -370,11 +370,11 @@ wheels = [
 
 [[package]]
 name = "netaddr"
-version = "0.8.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/3b/fe5bda7a3e927d9008c897cf1a0858a9ba9924a6b4750ec1824c9e617587/netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243", size = 1891561, upload-time = "2020-07-03T14:43:37.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/90/188b2a69654f27b221fba92fda7217778208532c962509e959a9cee5229d/netaddr-1.3.0.tar.gz", hash = "sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a", size = 2260504, upload-time = "2024-05-28T21:30:37.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/cd/9cdfea8fc45c56680b798db6a55fa60a22e2d3d3ccf54fc729d083b50ce4/netaddr-0.8.0-py2.py3-none-any.whl", hash = "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac", size = 1896631, upload-time = "2020-07-03T14:43:51.926Z" },
+    { url = "https://files.pythonhosted.org/packages/12/cc/f4fe2c7ce68b92cbf5b2d379ca366e1edae38cccaad00f69f529b460c3ef/netaddr-1.3.0-py3-none-any.whl", hash = "sha256:c2c6a8ebe5554ce33b7d5b3a306b71bbb373e000bbbf2350dd5213cc56e3dbbe", size = 2262023, upload-time = "2024-05-28T21:30:34.191Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrade netaddr dependency from `~=0.8.0` to `>=1.0.0,<2` (resolves to netaddr 1.3.0).

All 30 tests pass without any code changes — the cidrize codebase is already compatible with the netaddr 1.x API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency major-version bump may introduce subtle behavioral/API differences at runtime despite unchanged code; workflow change is low risk but could affect automated version preview output if incorrect.
> 
> **Overview**
> Upgrades `netaddr` from `~=0.8.0` to `>=1.0.0,<2` (locking to `netaddr` 1.3.0 in `uv.lock`) and updates the project metadata accordingly.
> 
> Fixes the release preview GitHub Action to use `python-semantic-release version --print` (replacing the previous dry-run flag) when computing the next version/changelog preview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24118aeb7681e80710d0146c23d404757dd770ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->